### PR TITLE
Allow the use of this library for cross-domain communication.

### DIFF
--- a/src/paginate-anything.js
+++ b/src/paginate-anything.js
@@ -37,6 +37,7 @@ exports = module.exports = function(req, res, total_items, max_range_size)
 	
 	res.setHeader('Accept-Ranges', 'items');
 	res.setHeader('Range-Unit', 'items');
+	res.setHeader('Access-Control-Expose-Headers', 'Content-Range, Accept-Ranges, Range-Unit');
 	
 	
 	max_range_size = parseInt(max_range_size);


### PR DESCRIPTION
This adds an ```Access-Control-Expose-Headers``` directive that enables this capability when it is being used cross domain.